### PR TITLE
Dispose off connection after a test has run

### DIFF
--- a/tests/test_order_items.py
+++ b/tests/test_order_items.py
@@ -1,9 +1,6 @@
 """ Module for Order Item tests """
 import unittest
-import os
 from service.models import OrderItem, DataValidationError
-
-DATABASE_URI = os.getenv("TEST_DB_URI", "postgres://postgres:postgres@localhost:5432/testdb")
 
 
 ######################################################################

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -33,6 +33,7 @@ class TestOrders(unittest.TestCase):
     def tearDown(self):
         db.session.remove()
         db.drop_all()
+        db.engine.dispose()
 
     def test_init_order(self):
         """ Initialize an order and assert that it exists """

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -54,8 +54,10 @@ class TestOrderService(TestCase):
         self.app = app.test_client()
 
     def tearDown(self):
+        """ Runs after each test """
         db.session.remove()
         db.drop_all()
+        db.engine.dispose()
 
     def _create_orders(self, count):
         """ Factory method to create orders in bulk """


### PR DESCRIPTION
Currently ElephantSQL only allows 5 connections. We need to dispose the connection after each test run.